### PR TITLE
replace vext, vext.gi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,5 @@ wolframalpha==3.0.1
 xmltodict==0.12.0
 pymongo==3.10.1
 playsound==1.2.2
-vext==0.7.3
-vext.gi==0.7.0
+pygobject
 word2number==1.1

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,9 @@ sudo apt-get install portaudio19-dev python-pyaudio python3-pyaudio && /
 sudo apt-get install libasound2-plugins libsox-fmt-all libsox-dev sox ffmpeg && /
 sudo apt-get install espeak && /
 sudo apt-get install python3-pip && /
-sudo apt-get install python3-setuptools
+sudo apt-get install python3-setuptools && /
+sudo apt-get install libcairo2-dev libgirepository1.0-dev gir1.2-gtk-3.0
+
 
 RESULT=$?
 if  [ $RESULT -eq 0 ]; then


### PR DESCRIPTION
install gobject directly via pip, replacing vext, vext.gi avoiding possible error "no module nemed 'gi'"

reference:
https://github.com/stuaxo/vext/issues/69