### PR TITLE
spelling mistake in line 86.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ bash setup.sh
 **NOTE:** *For better exprerience, before you start the application you can put the free KEYs in the settings.py*
 
 ```bash
-nano Jarvis/src/jarvis/jarvis/setting.py
+nano Jarvis/src/jarvis/jarvis/settings.py
 ```
 
 ### Start voice commanding assistant


### PR DESCRIPTION
It should be 'settings.py' and not 'setting.py' in Readme.md file.